### PR TITLE
fix: add missing <CRLF> to LIST error response

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -710,7 +710,7 @@ FtpConnection.prototype._listFiles = function(fileInfos, detailed, cmd) {
 
       function success(err) {
         if (err)
-          wwenc(self.socket, "550 Error listing files");
+          wwenc(self.socket, "550 Error listing files\r\n");
         else
           wwenc(self.socket, END_MSGS[cmd]);
         if (cmd != 'STAT')


### PR DESCRIPTION
each server response must end with <CRLF> (Telnet EOL marker)

http://www.ietf.org/rfc/rfc959.txt
