### PR TITLE
fix: lock users in chroot jail

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -24,15 +24,15 @@ var starttls = require('./starttls');
  - maybe just for milesplit's use?
  */
 
-function withCwd(cwd, p) {
-  if (!cwd)
-    return p;
-  else if (!p)
-    return cwd;
-  else if (p.length > 0 && (p.charAt(0) == '/' || p.charAt(0) == pathModule.sep))
-    return p;
-  else
-    return pathModule.join(cwd, p);
+function withCwd(cwd, path) {
+  var firstChar = (path || '').charAt(0);
+  cwd = cwd || pathModule.sep;
+  path = path || pathModule.sep;
+  if (firstChar === '/' || firstChar === pathModule.sep) {
+    cwd = pathModule.sep;
+  }
+  path = pathModule.join(cwd, path);
+  return path;
 }
 
 // Currently used for stripping options from beginning of argument to LIST and NLST.


### PR DESCRIPTION
Please reference comments on asylumfunk/nodeftpd#5 and https://github.com/asylumfunk/nodeftpd/commit/6608b2d06951320759e08fac16650e8d85d3ef3f

This is a heftier commit than I've pushed before, so please ask away if anything is unclear.

I've tested this on both *NIX and WIN machines (as it deals with path separators), but please be diligent as this touches every(?) filesystem access method (implicitly or explicitly).
