### PR TITLE
fix LIST test case

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -717,17 +717,16 @@ FtpConnection.prototype._listFiles = function(fileInfos, detailed, cmd) {
       for (var i = 0; i < fileInfos.length; ++i) {
         var fileInfo = fileInfos[i];
 
-        var line;
+        var line = '';
 
         if (!detailed) {
           var file = fileInfo;
-          line = file.name + "\r\n";
+          line += file.name + '\r\n';
         }
         else {
           var file = fileInfo.file;
-          line = "";
           var s = file.stats;
-          line = s.isDirectory() ? 'd' : '-';
+          line += s.isDirectory() ? 'd' : '-';
           line += (0400 & s.mode) ? 'r' : '-';
           line += (0200 & s.mode) ? 'w' : '-';
           line += (0100 & s.mode) ? 'x' : '-';

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node FTP Server",
   "main": "./lib/ftpd.js",
   "scripts": {
-    "test" : "mocha specs/* --globals commandArg"
+    "test": "mocha specs/* --globals commandArg"
   },
   "repository": {
     "type": "git",
@@ -17,25 +17,49 @@
   ],
   "author": "sstur",
   "contributors": [
-      { "name": "Alex Drummond", "url": "https://github.com/addrummond" },
-      { "name": "Eric Fong", "url": "https://github.com/ericfong" },
-      { "name": "headconnect", "url": "https://github.com/headconnect" },
-      { "name": "Andrew Johnston", "url": "https://github.com/billywhizz" },
-      { "name": "José F. Romaniello", "url": "https://github.com/jfromaniello" },
-      { "name": "Simon Sturmer", "url": "https://github.com/sstur" },
-      { "name": "Alan Szlosek", "url": "https://github.com/alanszlosek" },
-      { "name": "asylumfunk", "url": "https://github.com/asylumfunk" }
+    {
+      "name": "Alex Drummond",
+      "url": "https://github.com/addrummond"
+    },
+    {
+      "name": "Eric Fong",
+      "url": "https://github.com/ericfong"
+    },
+    {
+      "name": "headconnect",
+      "url": "https://github.com/headconnect"
+    },
+    {
+      "name": "Andrew Johnston",
+      "url": "https://github.com/billywhizz"
+    },
+    {
+      "name": "José F. Romaniello",
+      "url": "https://github.com/jfromaniello"
+    },
+    {
+      "name": "Simon Sturmer",
+      "url": "https://github.com/sstur"
+    },
+    {
+      "name": "Alan Szlosek",
+      "url": "https://github.com/alanszlosek"
+    },
+    {
+      "name": "asylumfunk",
+      "url": "https://github.com/asylumfunk"
+    }
   ],
   "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/sstur/nodeftpd/issues"
   },
   "dependencies": {
-      "dateformat": "1.0.7-1.2.3"
+    "dateformat": "1.0.7-1.2.3"
   },
   "devDependencies": {
     "async": "~0.1.15",
-    "mocha": "~0.12.1",
+    "mocha": "~1.17.1",
     "should": "~0.5.1",
     "jsftp": "*",
     "multiparter": ">=0.1.4",

--- a/specs/list.specs.js
+++ b/specs/list.specs.js
@@ -1,55 +1,80 @@
-require('should');
-var ftpd = require('../ftpd'),
-    Ftp = require("jsftp"),
-    path = require('path'),
-    fs = require('fs');
+var Server = require('../').FtpServer,
+  Client = require('jsftp'),
+  fs = require('fs'),
+  path = require('path'),
+  should = require('should');
 
+describe('LIST command', function () {
+  'use strict';
 
-describe('LIST ftpd command', function() {
-  var ftp, server;
+  var client,
+    server,
+    options = {
+      host: '127.0.0.1',
+      port: 2021,
+      user: 'jose',
+      pass: 'esoj',
+      root: '/../fixture'
+    };
 
-  beforeEach(function(done) {
-    server = new ftpd.FtpServer("127.0.0.1", {
-      getRoot: function(u) {
-        return fs.realpathSync(path.join(__dirname, '/../fixture', u));
+  beforeEach(function (done) {
+    server = new Server(options.host, {
+      getRoot: function (connection, callback) {
+        var username = connection.username,
+          root = path.join(__dirname, options.root, username);
+        fs.realpath(root, callback);
+      },
+      getInitialCwd: function () {
+        return path.sep;
       }
     });
-    server.on("client:connected", function(cinfo) {
+    server.on('client:connected', function (connection) {
       var username;
-      cinfo.on("command:user", function(user, success, failure) {
-        if (user) {
+      connection.on('command:user', function (user, success, failure) {
+        if (user === options.user) {
           username = user;
           success();
-        } else failure();
+        } else {
+          failure();
+        }
       });
-
-      cinfo.on("command:pass", function(pass, success, failure) {
-        if (pass) success(username);
-        else failure();
+      connection.on('command:pass', function (pass, success, failure) {
+        if (pass === options.pass) {
+          success(username);
+        } else {
+          failure();
+        }
       });
     });
-    server.listen(2021);
-    ftp = new Ftp({
-      host: "127.0.0.1",
-      port: 2021
+    server.listen(options.port);
+    client = new Client({
+      host: options.host,
+      port: options.port
     });
-    ftp.auth("jose", "esoj", function(err, res) {
+    client.auth(options.user, options.pass, function (error, response) {
+      should.not.exist(error);
+      should.exist(response);
+      response.should.have.property('code', 230);
       done();
     });
   });
 
-  it("should return - as a first character for files", function(done) {
-    ftp.list("/", function(err, d) {
-      var fileLine = d.substring(1).trim().split("\r\n")
-          .filter(function(line) {
-            return line.indexOf("data.txt") !== -1;
-          })[0];
-      fileLine[0].should.eql("-");
+  it('should return "-" as first character for files', function (done) {
+    client.list(path.sep, function (error, directoryListing) {
+      should.not.exist(error);
+      directoryListing = directoryListing
+        .split('\r\n')
+        .filter(function (line) {
+          return line.indexOf(' data.txt') !== -1;
+        });
+      should(directoryListing).have.lengthOf(1);
+      directoryListing[0].should.startWith('-');
       done();
     });
   });
 
-  afterEach(function() {
+  afterEach(function () {
     server.close();
   });
 });
+


### PR DESCRIPTION
As briefly mentioned in asylumfunk/nodeftpd#6, this test case had fallen into an unexecutable state.

This brings the (single) `LIST` test case up to date.

Beyond the cleanup, a few more assertions (or rather, `should`s) were included and the filesystem lookup is now performed asynchronously.

The only change to the library itself is the padding of `LIST/NLST/STAT` responses with a space, to clearly mark them as multiline, non-reply code responses.

`package.json` whitespace changes resulted from my Mocha installation.
