### PR TITLE
create common file to share between tests

### DIFF
--- a/specs/common.js
+++ b/specs/common.js
@@ -1,0 +1,58 @@
+var path = require('path');
+var fs = require('fs');
+var Server = require('../').FtpServer,
+  Client = require('jsftp'),
+  should = require('should'),
+  options = {
+    'host': process.env.IP || '127.0.0.1',
+    'port': process.env.port || 7002,
+    'user': 'jose',
+    'pass': 'esoj',
+    'root': '../fixture'
+  };
+
+module.exports = {
+  'should': should,
+  'server': function () {
+    return new Server(options.host, {
+      getRoot: function (connection, callback) {
+        var username = connection.username,
+          root = path.join(__dirname, options.root, username);
+        fs.realpath(root, callback);
+      },
+      getInitialCwd: function () {
+        return path.sep;
+      }
+    }).on('client:connected', function (connection) {
+      var username;
+      connection.on('command:user', function (user, success, failure) {
+        if (user === options.user) {
+          username = user;
+          success();
+        } else {
+          failure();
+        }
+      }).on('command:pass', function (pass, success, failure) {
+        if (pass === options.pass) {
+          success(username);
+        } else {
+          failure();
+        }
+      });
+    }).listen(options.port);
+  },
+  'client': function (done) {
+    var client = new Client({
+        host: options.host,
+        port: options.port
+      });
+    client.auth(options.user, options.pass, function (error, response) {
+        should.not.exist(error);
+        should.exist(response);
+        response.should.have.property('code', 230);
+        done();
+      });
+    return client;
+  }
+};
+

--- a/specs/list.specs.js
+++ b/specs/list.specs.js
@@ -1,73 +1,25 @@
-var Server = require('../').FtpServer,
-  Client = require('jsftp'),
-  fs = require('fs'),
-  path = require('path'),
-  should = require('should');
+var common = require('./common');
 
 describe('LIST command', function () {
   'use strict';
 
   var client,
-    server,
-    options = {
-      host: '127.0.0.1',
-      port: 2021,
-      user: 'jose',
-      pass: 'esoj',
-      root: '/../fixture'
-    };
+    server;
 
   beforeEach(function (done) {
-    server = new Server(options.host, {
-      getRoot: function (connection, callback) {
-        var username = connection.username,
-          root = path.join(__dirname, options.root, username);
-        fs.realpath(root, callback);
-      },
-      getInitialCwd: function () {
-        return path.sep;
-      }
-    });
-    server.on('client:connected', function (connection) {
-      var username;
-      connection.on('command:user', function (user, success, failure) {
-        if (user === options.user) {
-          username = user;
-          success();
-        } else {
-          failure();
-        }
-      });
-      connection.on('command:pass', function (pass, success, failure) {
-        if (pass === options.pass) {
-          success(username);
-        } else {
-          failure();
-        }
-      });
-    });
-    server.listen(options.port);
-    client = new Client({
-      host: options.host,
-      port: options.port
-    });
-    client.auth(options.user, options.pass, function (error, response) {
-      should.not.exist(error);
-      should.exist(response);
-      response.should.have.property('code', 230);
-      done();
-    });
+    server = common.server();
+    client = common.client(done);
   });
 
   it('should return "-" as first character for files', function (done) {
-    client.list(path.sep, function (error, directoryListing) {
-      should.not.exist(error);
+    client.list('/', function (error, directoryListing) {
+      common.should.not.exist(error);
       directoryListing = directoryListing
         .split('\r\n')
         .filter(function (line) {
           return line.indexOf(' data.txt') !== -1;
         });
-      should(directoryListing).have.lengthOf(1);
+      directoryListing.should.have.lengthOf(1);
       directoryListing[0].should.startWith('-');
       done();
     });

--- a/specs/retr.specs.js
+++ b/specs/retr.specs.js
@@ -1,77 +1,27 @@
-var Server = require('../').FtpServer,
-  Client = require('jsftp'),
-  fs = require('fs'),
-  path = require('path'),
-  should = require('should');
+var common = require('./common');
 
 describe('RETR command', function () {
   'use strict';
 
   var client,
-    server,
-    options = {
-      host: '127.0.0.1',
-      port: 2021,
-      user: 'jose',
-      pass: 'esoj',
-      root: '/../fixture'
-    };
+    server;
 
   beforeEach(function (done) {
-    server = new Server(options.host, {
-      getRoot: function (connection, callback) {
-        var username = connection.username,
-          root = path.join(__dirname, options.root, username);
-        fs.realpath(root, callback);
-      },
-      getInitialCwd: function () {
-        return path.sep;
-      }
-    });
-    server.on('client:connected', function (connection) {
-      var username;
-      connection.on('command:user', function (user, success, failure) {
-        if (user === options.user) {
-          username = user;
-          success();
-        } else {
-          failure();
-        }
-      });
-      connection.on('command:pass', function (pass, success, failure) {
-        if (pass === options.pass) {
-          success(username);
-        } else {
-          failure();
-        }
-      });
-    });
-    server.listen(options.port);
-    client = new Client({
-      host: options.host,
-      port: options.port
-    });
-    client.auth(options.user, options.pass, function (error, response) {
-      should.not.exist(error);
-      should.exist(response);
-      response.should.have.property('code', 230);
-      done();
-    });
+    server = common.server();
+    client = common.client(done);
   });
 
   it('should contain "hola!"', function (done) {
     var str = '';
     client.get('/data.txt', function (error, socket) {
-      should.not.exist(error);
+      common.should.not.exist(error);
       socket.on('data', function (data) {
         str += data.toString();
-      });
-      socket.on('close', function (error) {
+      }).on('close', function (error) {
         error.should.not.equal(true);
         str.should.eql('hola!');
         done();
-      });
-      socket.resume();
+      }).resume();
     });
   });
 


### PR DESCRIPTION
With `require('./common')` in our test files, we gain access to helper methods to make test creation much easier moving forward.
- `common.server()` creates a new server with default values that is already listening on the configured port.
- `common.client()` creates a new client that connects to and authenticates with the server.
