### PR TITLE
reply 502 to unsupported commands

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -353,15 +353,6 @@ FtpConnection.prototype._onClose = function() {
   this._logIf(0, "Client connection closed");
 };
 
-var NOT_SUPPORTED = { }; // (But recognized)
-[ 'ABOR', 'ACCT', 'ADAT', 'ALLO', 'APPE', 'CCC',
-  'CONF', 'ENC', 'HELP', 'LANG', 'LPRT', 'LPSV',
-  'MIC', 'MLSD', 'MLST', 'MODE', 'OPTS', 'REIN',
-  'SITE', 'SMNT', 'STOU', 'STRU', 'SYST'
-].forEach(function (ns) {
-      NOT_SUPPORTED[ns] = true;
-    });
-
 // Whitelist of commands which don't require authentication.
 // All other commands sent by unauthorized users will be rejected by default.
 var DOES_NOT_REQUIRE_AUTH = { };
@@ -427,11 +418,8 @@ FtpConnection.prototype._onData = function(data) {
       self[m](commandArg, command);
     }
   }
-  else if (NOT_SUPPORTED[command]) {
-    self.respond("202 Not supported");
-  }
   else {
-    self.respond("202 Not recognized");
+    self.respond('502 Command not implemented.');
   }
 };
 

--- a/test/unsupported.js
+++ b/test/unsupported.js
@@ -1,0 +1,52 @@
+var common = require('./common');
+
+describe('UNSUPPORTED commands', function () {
+  'use strict';
+
+  var client,
+    server,
+    commands = [
+      //RFC959
+      'ABOR',
+      'ACCT',
+      'ALLO',
+      'HELP',
+      'MODE',
+      'REIN',
+      'REST',
+      'SITE',
+      'SMNT',
+      'STOU',
+      'STRU',
+      //Fake
+      'FAKE',
+      'COMMAND',
+      'LS',
+      'CD'
+    ];
+
+  beforeEach(function (done) {
+    server = common.server();
+    client = common.client(done);
+  });
+
+  commands.forEach(function (command) {
+    it('should reply 502 to ' + command, function (done) {
+      var callback = function (error) {
+        error.code.should.eql(502);
+        done();
+      };
+      command = command.toLowerCase();
+      if (client.raw[command]) {
+        client.raw[command](callback);
+      } else {
+        client.execute(command, callback);
+      }
+    });
+  });
+
+  afterEach(function () {
+    server.close();
+  });
+});
+


### PR DESCRIPTION
If the related method does not exist (currently `FtpConnection.prototype._command_COMMANDNAME`), the command is not supported. The `NOT_SUPPORTED` object was a distinction without difference. Not only only was it unneeded overhead, but it had also fallen out-of-sync, as it still included `FEAT` as an unsupported command, despite having been included in the initial commit at 8d658d9590d43ccf8d04e8637b7fed937be9c1dc. `SYST` appears to have been marked as unsupported at cf39462b7bdaa21a2ec4a3ae0304170997384497 .

Relevant tests have also been created.  Take note, the commands included in the test file are the only ones which we are currently able to test via `jsftp`, as said library doesn't offer full RFC959 (or beyond) compliance (nor will it allow arbitrary commands).  I have already forked the project and begun pushing upstream on an as-needed basis, but in the interim, feel free to issue raw commands connecting via TELNET or your favorite FTP client.

Additional information on reply codes at asylumfunk#17 and of course in the RFCs.
