### PR TITLE
ensure intiial CWD is always an absolute path

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -27,7 +27,7 @@ var starttls = require('./starttls');
 function withCwd(cwd, path) {
   var firstChar = (path || '').charAt(0);
   cwd = cwd || pathModule.sep;
-  path = path || pathModule.sep;
+  path = path || '';
   if (firstChar === '/' || firstChar === pathModule.sep) {
     cwd = pathModule.sep;
   }

--- a/test/pwd.js
+++ b/test/pwd.js
@@ -11,6 +11,11 @@ describe('PWD command', function () {
       path.join(path.sep, 'public_html'),
       path.join(path.sep, 'public_html', 'tmp'),
       path.join(path.sep, 'tmp')
+    ],
+    falseyDirectories = [
+      '',
+      null,
+      undefined
     ];
 
   directories.forEach(function (directory) {
@@ -35,6 +40,30 @@ describe('PWD command', function () {
         client.raw.pwd(directory, function (error, reply) {
           error.code.should.equal(501);
           reply.code.should.equal(501);
+          done();
+        });
+      });
+
+      afterEach(function () {
+        server.close();
+      });
+    });
+  });
+
+  falseyDirectories.forEach(function (directory) {
+    describe('CWD = "' + directory + '"', function () {
+      beforeEach(function (done) {
+        server = common.server({
+          cwd: directory
+        });
+        client = common.client(done);
+      });
+
+      it('should be "/"', function (done) {
+        client.raw.pwd(function (error, reply) {
+          common.should.not.exist(error);
+          reply.code.should.equal(257);
+          reply.text.should.startWith('257 "/"');
           done();
         });
       });


### PR DESCRIPTION
This PR is broken into 4 commits:
1. Ensures that the initial working directory will always be an absolute path (within the chroot)
2. Refactor the USER/PASS commands
3. Accept `PASS` commands only immediately after a `USER` command.
4. Whitespace

Reply messages have been updated to match RFC959.
