### PR TITLE
implement ALLO command

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -423,6 +423,11 @@ FtpConnection.prototype._onData = function(data) {
   }
 };
 
+FtpConnection.prototype._command_ALLO = function () {
+  this.respond('202 Command not implemented, superfluous at this site.');
+  return this;
+};
+
 FtpConnection.prototype._command_AUTH = function(commandArg) {
   var self = this;
 

--- a/test/allo.js
+++ b/test/allo.js
@@ -1,0 +1,26 @@
+var common = require('./common');
+
+describe('ALLO command', function () {
+  'use strict';
+
+  var client,
+    server;
+
+  beforeEach(function (done) {
+    server = common.server();
+    client = common.client(done);
+  });
+
+  it('should reply 202', function (done) {
+    client.execute('ALLO', function (error, reply) {
+      common.should.not.exist(error);
+      reply.code.should.equal(202);
+      done();
+    });
+  });
+
+  afterEach(function () {
+    server.close();
+  });
+});
+

--- a/test/unsupported.js
+++ b/test/unsupported.js
@@ -9,7 +9,6 @@ describe('UNSUPPORTED commands', function () {
       //RFC959
       'ABOR',
       'ACCT',
-      'ALLO',
       'HELP',
       'MODE',
       'REIN',


### PR DESCRIPTION
We don't need to allocate filespace (or at least I don't currently see the use case), so we should let the user know to proceed anyway with a positive `202` reply.
