### PR TITLE
implement ACCT command

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -425,6 +425,11 @@ FtpConnection.prototype._onData = function(data) {
   self.previousCommand = command;
 };
 
+FtpConnection.prototype._command_ACCT = function () {
+  this.respond('202 Command not implemented, superfluous at this site.');
+  return this;
+};
+
 FtpConnection.prototype._command_ALLO = function () {
   this.respond('202 Command not implemented, superfluous at this site.');
   return this;

--- a/test/acct.js
+++ b/test/acct.js
@@ -1,0 +1,27 @@
+var common = require('./common');
+
+describe('ACCT command', function () {
+  'use strict';
+
+  var client,
+    server;
+
+  beforeEach(function (done) {
+    server = common.server();
+    client = common.client(done);
+  });
+
+  it('should reply 202', function (done) {
+    client.execute('ACCT', function (error, reply) {
+      common.should.not.exist(error);
+      reply.code.should.equal(202);
+      done();
+    });
+  });
+
+  afterEach(function () {
+    server.close();
+  });
+});
+
+

--- a/test/unsupported.js
+++ b/test/unsupported.js
@@ -8,7 +8,6 @@ describe('UNSUPPORTED commands', function () {
     commands = [
       //RFC959
       'ABOR',
-      'ACCT',
       'HELP',
       'MODE',
       'REIN',


### PR DESCRIPTION
Currently superfluous, responds with `202` to alert user to proceed anyway. Stubbed out for future extension.

Relevant test coverage included.

From RFC959:

```
     ACCOUNT (ACCT)

        The argument field is a Telnet string identifying the user's
        account.  The command is not necessarily related to the USER
        command, as some sites may require an account for login and
        others only for specific access, such as storing files.  In
        the latter case the command may arrive at any time.

        There are reply codes to differentiate these cases for the
        automation: when account information is required for login,
        the response to a successful PASSword command is reply code
        332.  On the other hand, if account information is NOT
        required for login, the reply to a successful PASSword
        command is 230; and if the account information is needed for
        a command issued later in the dialogue, the server should
        return a 332 or 532 reply depending on whether it stores
        (pending receipt of the ACCounT command) or discards the
        command, respectively.
```
