### PR TITLE
add istanbul dependency for test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node FTP Server",
   "main": "./lib/ftpd.js",
   "scripts": {
-    "test": "mocha"
+    "test": "node_modules/.bin/istanbul test _mocha"
   },
   "repository": {
     "type": "git",
@@ -61,6 +61,7 @@
     "async": "~0.1.15",
     "mocha": "~1.17.1",
     "should": "~3.1.2",
-    "jsftp": "git://github.com/sergi/jsftp.git#master"
+    "jsftp": "git://github.com/sergi/jsftp.git#master",
+    "istanbul": "~0.2.4"
   }
 }


### PR DESCRIPTION
> Yet another JS code coverage tool that computes statement, line, function and branch coverage with module loader hooks to transparently add coverage when running tests. Supports all JS coverage use cases including unit tests, server side functional tests and browser tests. Built for scale.
> - https://github.com/yahoo/istanbul

Install dependencies with:
`npm install`

Run tests normally:
`npm test`

Run tests and calculate coverage:
`npm test --coverage`

Coverage can be viewed from:
`./coverage/lcov-report/index.html`
