### PR TITLE
refactor CWD

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -487,29 +487,30 @@ FtpConnection.prototype._command_CDUP = function(commandArg) {
 };
 
 FtpConnection.prototype._command_CWD = function(commandArg) {
-  var self = this;
+  var self = this,
+    path = withCwd(self.cwd, commandArg),
+    fspath = pathModule.join(self.root, path);
 
-  var path = withCwd(self.cwd, commandArg);
-  var fspath = pathModule.join(self.root, path);
   self.fs.stat(fspath, function(err, stats) {
     if (err) {
-      if (err.code != 'ENOENT') {
-        self._logIf(0, "Error other than ENOENT in call to 'stat'" + err);
-        self.respond("550 Error reading folder.");
+      if (err.code === 'ENOENT') {
+        self.respond("550 Directory not found.");
       }
       else {
-        self.respond("550 Folder not found");
+        self._logIf(0, 'Error other than ENOENT in call to "stat"' + err);
+        self.respond('550 Directory not available.');
       }
     }
     else if (!stats.isDirectory()) {
-      self._logIf(3, "Attempt to CWD to non-directory");
-      self.respond("550 Not a directory");
+      self._logIf(3, 'Attempt to CWD to non-directory');
+      self.respond('550 Not a directory');
     }
     else {
       self.cwd = path;
-      self.respond("250 CWD successful. \"" + self.cwd + "\" is current directory");
+      self.respond('250 CWD successful. "' + self.cwd + '" is current directory');
     }
   });
+  return this;
 };
 
 FtpConnection.prototype._command_DELE = function(commandArg) {


### PR DESCRIPTION
check for strict equality
declare variables in a single statement
call them "directories" not "folders"
return this for chaining
use single quotes
