### PR TITLE
Setup passive data handlers immediately upon STOR command

### DIFF
--- a/lib/ftpd.js
+++ b/lib/ftpd.js
@@ -1258,6 +1258,14 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initia
   var startTime = new Date();
   var uploadSize = 0;
 
+  if (initialBuffers) {
+    initialBuffers.forEach(function(b) {
+      storeStream.write(b);
+    });
+  }
+
+  self._whenDataReady(handleUpload);
+
   storeStream.on("open", function(fd) {
     self._logIf(3, "File opened/created: " + filename);
     self._logIf(3, "Told client ok to send file data");
@@ -1268,17 +1276,7 @@ FtpConnection.prototype._STOR_usingCreateWriteStream = function(filename, initia
       time: startTime
     });
 
-    if (initialBuffers) {
-      initialBuffers.forEach(function(b) {
-        storeStream.write(b);
-      });
-      handleUpload();
-    }
-    else {
-      self.respond("150 Ok to send data", function() {
-        self._whenDataReady(handleUpload);
-      });
-    }
+    self.respond("150 Ok to send data");
   });
 
   storeStream.on("error", function(err) {


### PR DESCRIPTION
Some clients won't wait for '150 ok send data' and instead will start sending data immediately assuming positive response from server on STOR command: http://trac.filezilla-project.org/ticket/5063

This breaks uploading of really small files - data is sent and dataSocket is closed even before handleUpload() was able to set its 'data' listeners.
