### PR TITLE
updated readme example with proper parameter type in getInitialCwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Create the FTPServer (simple example):
     var options = {
       pasvPortRangeStart: 4000,
       pasvPortRangeEnd: 5000,
-      getInitialCwd: function(user, callback) {
-        var userPath = process.cwd() + '/' + user;
+      getInitialCwd: function(connection, callback) {
+        var userPath = process.cwd() + '/' + connection.username;
         fs.exists(userPath, function(exists) {
           exists ? callback(null, userPath) : callback('path does not exist', userPath);
         });


### PR DESCRIPTION
fixes minor Readme doc bug where the type retured from getInitialCwd callback isnt a string but the connection object.
