### PR TITLE
/bin/ls format fixes

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -600,6 +600,7 @@ FtpConnection.prototype._listFiles = function(fileInfos, detailed, cmd) {
       for (var i = 0; i < fileInfos.length; ++i) {
         var fileInfo = fileInfos[i];
 
+        var now = new Date();
         var line = '';
         var file;
 
@@ -618,7 +619,11 @@ FtpConnection.prototype._listFiles = function(fileInfos, detailed, cmd) {
             (fileInfo.gname === null ? 'ftp' : fileInfo.gname) + ' ';
           line += leftPad(s.size.toString(), 12) + ' ';
           var d = new Date(s.mtime);
-          line += leftPad(dateformat(d, 'mmm dd HH:MM'), 12) + ' ';
+          if (d.getTime() > (now.getTime() - (365 / 2 * 86400 * 1000))) {
+            line += leftPad(dateformat(d, 'mmm dd HH:MM'), 12) + ' ';
+          } else {
+            line += leftPad(dateformat(d, 'mmm dd  yyyy'), 12) + ' ';
+          }
           line += file.name;
           line += '\r\n';
         }

--- a/test/list.js
+++ b/test/list.js
@@ -41,8 +41,8 @@ describe('LIST command', function() {
       listing = common.splitResponseLines(listing);
       listing.should.have.lengthOf(1);
       var lsLongRgx = [
-        /($# file modes: ___|)[d-]([r-][w-][x-]){3}/,
-        /($# ?¿?¿? inodes?: |)\d+/,
+        /($# file modes: ___|)[d-]([r-][w-][xSstT-]){3}/,
+        /($# inodes________ |)\d+/,
         /($# owner name: ___|)\S+/,
         /($# owner group: __|)\S+/,
         /($# size in bytes: |)\d+/,


### PR DESCRIPTION
Files older than 6 months should have the year printed instead of the time according to the /bin/ls format.
