### PR TITLE
Simple Whitelist for File Extensions

### DIFF
--- a/lib/FtpConnection.js
+++ b/lib/FtpConnection.js
@@ -1073,14 +1073,31 @@ FtpConnection.prototype._command_RNFR = function(commandArg) {
 FtpConnection.prototype._command_RNTO = function(commandArg) {
   var self = this;
   var fileto = withCwd(self.cwd, commandArg);
-  self.fs.rename(pathModule.join(self.root, self.filefrom), pathModule.join(self.root, fileto), function(err) {
-    if (err) {
-      self._logIf(LOG.ERROR, 'Error renaming file from ' + self.filefrom + ' to ' + fileto);
-      self.respond('550 Rename failed' + (err.code === 'ENOENT' ? '; file does not exist' : ''));
-    } else {
-      self.respond('250 File renamed successfully');
-    }
-  });
+
+  // Filter extensions if whitelist available
+  var whitelist = self.server.options.allowedExtensions;
+  var accepted = true;
+  if (whitelist && typeof whitelist === 'object' && Array.isArray(whitelist) && whitelist.length) {
+    accepted = false;
+    whitelist.forEach(function (ext) {
+      if (fileto.endsWith(ext)) accepted = true;
+    });
+  }
+  if (accepted) {
+    self.fs.rename(pathModule.join(self.root, self.filefrom), pathModule.join(self.root, fileto), function(err) {
+      if (err) {
+        self._logIf(LOG.ERROR, 'Error renaming file from ' + self.filefrom + ' to ' + fileto);
+        self.respond('550 Rename failed' + (err.code === 'ENOENT' ? '; file does not exist' : ''));
+      } else {
+        self.respond('250 File renamed successfully');
+      }
+    });
+  } else {
+    self.respond("553 Rename failed; file type not allowed", function () {
+      self._logIf(3, "Disallowed renaming of file from " + self.filefrom + " to " + fileto);
+    });
+  }
+
 };
 
 FtpConnection.prototype._command_SIZE = function(commandArg) {
@@ -1227,7 +1244,7 @@ FtpConnection.prototype._STOR_usingWriteFile = function(filename, flag) {
       self._whenDataReady(handleUpload);
     });
   } else {
-    self.respond("553 Requested action not taken. File type not allowed.", function () {
+    self.respond("553 Requested file action aborted; file type not allowed", function () {
       if (self.dataSocket) self._closeSocket(self.dataSocket);
     });
   }


### PR DESCRIPTION
In many cases, you want to limit the file extensions saved on the server to prevent executables or other formats from being uploaded.