### PR TITLE
[minor][test] fix typo in tests: suppressExpecte(+d)ErrMsgs

### DIFF
--- a/test/cwd-cdup.js
+++ b/test/cwd-cdup.js
@@ -41,7 +41,7 @@ describe('CWD/CDUP commands', function() {
     it('should not change to non-existent directory', function(done) {
       client.raw('CWD', pathExisting, function(error, response) {
         response.code.should.equal(250);
-        server.suppressExpecteErrMsgs.push(
+        server.suppressExpectedErrMsgs.push(
           /^CWD \S+: Error: ENOENT/
         );
         client.raw('CWD', pathExisting, function(error) {

--- a/test/init.js
+++ b/test/init.js
@@ -38,7 +38,7 @@ describe('initialization', function() {
   it('should bail if getRoot fails', function(done) {
     server = common.server({
       getRoot: function(connection, callback) {
-        server.suppressExpecteErrMsgs.push(
+        server.suppressExpectedErrMsgs.push(
           'getRoot signaled error [Error: intentional failure]');
         callback(new Error('intentional failure'));
       },
@@ -85,7 +85,7 @@ describe('initialization', function() {
   it('should bail if getInitialCwd fails', function(done) {
     server = common.server({
       getInitialCwd: function(connection, callback) {
-        server.suppressExpecteErrMsgs.push(
+        server.suppressExpectedErrMsgs.push(
           'getInitialCwd signaled error [Error: intentional failure]');
         callback(new Error('intentional failure'));
       },

--- a/test/lib/common.js
+++ b/test/lib/common.js
@@ -80,12 +80,12 @@ var common = module.exports = {
       });
     });
     var origLogIf = server._logIf;
-    server.suppressExpecteErrMsgs = [];
+    server.suppressExpectedErrMsgs = [];
     server._logIf = function logIfNotExpected(verbosity, message, conn) {
-      var expecteErrMsgs = server.suppressExpecteErrMsgs;
+      var expectedErrMsgs = server.suppressExpectedErrMsgs;
       message = String(message).split(fixturesPath).join('fixture:/');
-      if ((expecteErrMsgs.length > 0) && (verbosity < LogLevels.LOG_INFO)) {
-        var expected = expecteErrMsgs.shift();
+      if ((expectedErrMsgs.length > 0) && (verbosity < LogLevels.LOG_INFO)) {
+        var expected = expectedErrMsgs.shift();
         if (message === expected) {
           return;
         }

--- a/test/mkd-rmd.js
+++ b/test/mkd-rmd.js
@@ -22,7 +22,7 @@ describe('MKD/RMD commands', function() {
     });
 
     it('should not create a duplicate directory', function(done) {
-      server.suppressExpecteErrMsgs.push(
+      server.suppressExpectedErrMsgs.push(
         /^MKD \S+: Error: EEXIST/
       );
       client.raw('MKD', directory, function(error) {
@@ -42,7 +42,7 @@ describe('MKD/RMD commands', function() {
     });
 
     it('should not delete a non-existent directory', function(done) {
-      server.suppressExpecteErrMsgs.push(
+      server.suppressExpectedErrMsgs.push(
         /^RMD \S+: Error: ENOENT/);
       client.raw('RMD', directory, function(error) {
         error.code.should.equal(550);

--- a/test/tricky-paths.js
+++ b/test/tricky-paths.js
@@ -38,7 +38,7 @@ describe('Tricky paths', function() {
         async.waterfall([
           function strangePathRedundantEscape(nxt) {
             var dirRfcQuoted = dirPath.replace(/"/g, '""');
-            server.suppressExpecteErrMsgs.push(
+            server.suppressExpectedErrMsgs.push(
               /^CWD [\S\s]+: Error: ENOENT/
             );
             client.raw('CWD', dirRfcQuoted, function(error) {


### PR DESCRIPTION
Fixes my typo from cf207f66aab57c66ffbf2ab6452b91ad84264ab4 .

Original master doesn't currently pass tests on my machine, so instead I diff-ed the test log from before and after, they're identical except for timing.